### PR TITLE
Add "laststock" to "Apply Standard Data"

### DIFF
--- a/engine/Shopware/Controllers/Backend/Article.php
+++ b/engine/Shopware/Controllers/Backend/Article.php
@@ -2382,6 +2382,7 @@ class Shopware_Controllers_Backend_Article extends Shopware_Controllers_Backend_
             $mainData['width'] = $mainDetail->getWidth();
             $mainData['height'] = $mainDetail->getHeight();
             $mainData['len'] = $mainDetail->getLen();
+            $mainData['lastStock'] = $mainDetail->getLastStock();
         }
         if ($mapping['attributes']) {
             $builder = Shopware()->Models()->createQueryBuilder();


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
This allows the user to apply the laststock flag from the preselection variant with the "Apply Standard Data" function in backend.

### 2. What does this change do, exactly?
Adds the "lastStock" information to the getMappingData function

### 3. Describe each step to reproduce the issue or behaviour.

Actually the last stock flag is not applied to the other variants if using "Apply Standard Data"

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/SW-23131

### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.