### PR TITLE
Add Banner Tracking Link to robots.txt

### DIFF
--- a/themes/Frontend/Bare/frontend/robots_txt/index.tpl
+++ b/themes/Frontend/Bare/frontend/robots_txt/index.tpl
@@ -13,6 +13,7 @@
     {$robotsTxt->setDisallow('/widgets')}
     {$robotsTxt->setDisallow('/listing')}
     {$robotsTxt->setDisallow('/ticket')}
+    {$robotsTxt->setDisallow('/tracking')}
 
     {block name="frontend_robots_txt_disallows_output"}
         {foreach $robotsTxt->getDisallows() as $disallow}


### PR DESCRIPTION
The tracking Link from the Banner module can cause errors in webmaster console, so we should disallow them.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?

To add /tracking to disallow

### 2. What does this change do, exactly?
...

### 3. Describe each step to reproduce the issue or behaviour.
Open robots.txt, and search for /tracking - it's not there.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.